### PR TITLE
Allow to provide a fallback agency url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,17 @@ go 1.20
 
 require (
 	github.com/paulmach/go.geojson v1.5.0
-	github.com/public-transport/gtfsparser v0.0.0-20240508211334-a2b010870a5e
+	github.com/public-transport/gtfsparser v0.0.0-20240710174704-2714e8eacded
 	github.com/public-transport/gtfswriter v0.0.0-20240530234004-bf8f5e60799e
 	github.com/spf13/pflag v1.0.5
 
 	// Remove this once our minimum Go version is forced to be 1.21
 	// This is only used for slices which are added in 1.21 stdlib
-	golang.org/x/exp v0.0.0-20240530194437-404ba88c7ed0
+	golang.org/x/exp v0.0.0-20240707233637-46b078467d37
 )
 
 require (
-	github.com/klauspost/compress v1.17.8 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/twotwotwo/sorts v0.0.0-20160814051341-bf5c1f2b8553 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
-github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/paulmach/go.geojson v1.5.0 h1:7mhpMK89SQdHFcEGomT7/LuJhwhEgfmpWYVlVmLEdQw=
 github.com/paulmach/go.geojson v1.5.0/go.mod h1:DgdUy2rRVDDVgKqrjMe2vZAHMfhDTrjVKt3LmHIXGbU=
-github.com/public-transport/gtfsparser v0.0.0-20240508211334-a2b010870a5e h1:GtM7hS//WJ69KZ7/iR0BjEDYzsYGzEG/NX0jrsrsYmk=
-github.com/public-transport/gtfsparser v0.0.0-20240508211334-a2b010870a5e/go.mod h1:VMH9/q8veNNZb7LLSQwLBLaQaab79LtyU6kx3P+b48Q=
+github.com/public-transport/gtfsparser v0.0.0-20240710174704-2714e8eacded h1:s3xyqN+KDjRXrzFzZMwjFSr+bJAfbiIobque7DTgSw8=
+github.com/public-transport/gtfsparser v0.0.0-20240710174704-2714e8eacded/go.mod h1:VMH9/q8veNNZb7LLSQwLBLaQaab79LtyU6kx3P+b48Q=
 github.com/public-transport/gtfswriter v0.0.0-20240530234004-bf8f5e60799e h1:C41PXKjBVvWn4hc9nKNx8atCmbgzthpKvoGdli4TN78=
 github.com/public-transport/gtfswriter v0.0.0-20240530234004-bf8f5e60799e/go.mod h1:pZBUjxz/q7rW+05aZnrJyW/sLwgYGIO7c1yGkPivNTU=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -12,5 +12,5 @@ github.com/twotwotwo/sorts v0.0.0-20160814051341-bf5c1f2b8553 h1:DRC1ubdb3ZmyyIe
 github.com/twotwotwo/sorts v0.0.0-20160814051341-bf5c1f2b8553/go.mod h1:Rj7Csq/tZ/egz+Ltc2IVpsA5309AmSMEswjkTZmq2Xc=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
-golang.org/x/exp v0.0.0-20240530194437-404ba88c7ed0 h1:Mi0bCswbz+9cXmwFAdxoo5GPFMKONUpua6iUdtQS7lk=
-golang.org/x/exp v0.0.0-20240530194437-404ba88c7ed0/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240707233637-46b078467d37 h1:uLDX+AfeFCct3a2C7uIWBKMJIR3CJMhcgfrUAqjRK6w=
+golang.org/x/exp v0.0.0-20240707233637-46b078467d37/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=

--- a/gtfsclean.go
+++ b/gtfsclean.go
@@ -129,6 +129,7 @@ func main() {
 	useDefaultValuesOnError := flag.BoolP("default-on-errs", "e", false, "if non-required fields have errors, fall back to the default values")
 	fixZip := flag.BoolP("fix-zip", "z", false, "try to fix some errors in the ZIP file directory hierarchy")
 	emptyStrRepl := flag.StringP("empty-str-repl", "p", "", "string to use if a non-critical required string field is empty (like stop_name, agency_name, ...)")
+	emptyAgencyUrlRepl := flag.StringP("empty-agency-url-repl", "", "", "url to use if agency_url is empty")
 	dropErroneousEntities := flag.BoolP("drop-errs", "D", false, "drop erroneous entries from feed")
 	checkNullCoords := flag.BoolP("check-null-coords", "n", false, "check for (0, 0) coordinates")
 
@@ -413,6 +414,9 @@ func main() {
 	opts.UseDefValueOnError = *useDefaultValuesOnError && !*onlyValidate
 	opts.CheckNullCoordinates = *checkNullCoords
 	opts.EmptyStringRepl = *emptyStrRepl
+	if *emptyAgencyUrlRepl != "" {
+		opts.EmptyAgencyUrlRepl = *emptyAgencyUrlRepl
+	}
 	opts.ZipFix = *fixZip
 	opts.ShowWarnings = *showWarnings
 	opts.DropShapes = *dropShapes


### PR DESCRIPTION
Needs lock file update after https://github.com/public-transport/gtfsparser/pull/3 is merged.