### PR TITLE
Update gtfs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gtfsclean
 
-Tidy (and validate) [GTFS](https://developers.google.com/transit/gtfs/) feeds.
+Tidy (and validate) [GTFS](https://gtfs.org/) feeds.
 
 Fixes small inconsistencies, minimizes the overall feed size, and prepares the feed for secure, standard-compliant further use.
 


### PR DESCRIPTION
Google turned down their GTFS Documentation to redirect to [gtfs.org](https://gtfs.org/) which always has the latest version of the spec, this PR updates the link in README.md. 