### PR TITLE
Add route name converter

### DIFF
--- a/processors/routenameconverter.go
+++ b/processors/routenameconverter.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Jonah Brüchert
+// Authors: jbb@kaidan.im
+//
+// Use of this source code is governed by a GPL v2
+// license that can be found in the LICENSE file
+
+package processors
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/public-transport/gtfsparser"
+)
+
+// RouteNameConverter copies the trip_short_name field into route_short_name based on a set of rules
+type RouteNameConverter struct {
+	KeepRouteNameRegex *regexp.Regexp
+	CopyTripNameRegex  *regexp.Regexp
+}
+
+func (f RouteNameConverter) Run(feed *gtfsparser.Feed) {
+	fmt.Fprintf(os.Stdout, "Copying selected trip names to route names...")
+
+	for _, trip := range feed.Trips {
+		route := trip.Route
+		if route == nil {
+			continue
+		}
+		if route.Short_name != "" && f.KeepRouteNameRegex != nil && f.KeepRouteNameRegex.MatchString(route.Short_name) {
+			continue
+		} else {
+			if trip.Short_name != nil && *trip.Short_name != "" && f.CopyTripNameRegex != nil && f.CopyTripNameRegex.MatchString(*trip.Short_name) {
+				newRouteId := route.Id + trip.Id
+				// todo copy
+				newRoute := (*route)
+				newRoute.Id = newRouteId
+				newRoute.Short_name = *trip.Short_name
+				feed.Routes[newRouteId] = &newRoute
+				trip.Route = &newRoute
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, " done.")
+}


### PR DESCRIPTION
This allows to copy specific values from trip_short_name to route_short_name to convert feeds to the Google Maps convention of putting whatever should be displayed into route_short_name.

Since there is no way in GTFS to model what should be displayed, this is currently the only way to do it and what MOTIS has also started doing.

Test using `./gtfsclean --copy-trip-names-matching "((IC)|(ECB)|(EC)|(RJ)|(RJX)|(D)|(NJ)|(EN)|(CJX)|(ICE)|(IR)|(REX)|(R)|(ER)|(ATB)) \d+" --keep-route-names-matching "((RE)|(RB)) \d+" transitous/out/at_Railway-Current-Reference-Data-2025.gtfs.zip`