### PR TITLE
Update gtfsparser/gtfswriter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/paulmach/go.geojson v1.5.0
-	github.com/public-transport/gtfsparser v0.0.0-20250315225605-cdafda3d5e46
-	github.com/public-transport/gtfswriter v0.0.0-20250109141303-0bbc5ae2d194
+	github.com/public-transport/gtfsparser v0.0.0-20250531164119-01696d00fd2b
+	github.com/public-transport/gtfswriter v0.0.0-20250531182842-8c0b4fbcffb4
 	github.com/spf13/pflag v1.0.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/paulmach/go.geojson v1.5.0 h1:7mhpMK89SQdHFcEGomT7/LuJhwhEgfmpWYVlVmLEdQw=
 github.com/paulmach/go.geojson v1.5.0/go.mod h1:DgdUy2rRVDDVgKqrjMe2vZAHMfhDTrjVKt3LmHIXGbU=
-github.com/public-transport/gtfsparser v0.0.0-20250315225605-cdafda3d5e46 h1:W1frFlQj9H3a0EmdrYay3bLzsPD3UV7A/fGr1DaiF6w=
-github.com/public-transport/gtfsparser v0.0.0-20250315225605-cdafda3d5e46/go.mod h1:WjAkhbrI3szwAlvRXjvyby3WO0yan8OUwayYuFURdmU=
-github.com/public-transport/gtfswriter v0.0.0-20250109141303-0bbc5ae2d194 h1:ITOKMEpcF/5OxI7FJ+Rk08yvExvfL5tZowy35Sxvfqg=
-github.com/public-transport/gtfswriter v0.0.0-20250109141303-0bbc5ae2d194/go.mod h1:xd3+150rasGihIKoBLICU/oWiamZLtwGmitGVwabUEY=
+github.com/public-transport/gtfsparser v0.0.0-20250531164119-01696d00fd2b h1:M7PquHLqtfxHVylHyhcq31pDohpANvpD7bfdUsviAsY=
+github.com/public-transport/gtfsparser v0.0.0-20250531164119-01696d00fd2b/go.mod h1:WjAkhbrI3szwAlvRXjvyby3WO0yan8OUwayYuFURdmU=
+github.com/public-transport/gtfswriter v0.0.0-20250531182842-8c0b4fbcffb4 h1:5dOnbkbDBzIvgOjpBZ7812FBFFhB672l9CW2eVavAdo=
+github.com/public-transport/gtfswriter v0.0.0-20250531182842-8c0b4fbcffb4/go.mod h1:jgQC4QV51OCw74wZ9bzva7sqSWpRTF4G/yp2XkTelqk=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/twotwotwo/sorts v0.0.0-20160814051341-bf5c1f2b8553 h1:DRC1ubdb3ZmyyIeCSTxjZIQAnpLPfKVgYrLETQuOPjo=


### PR DESCRIPTION
This will make --keep-additional-fields also preserve additional files. Relevant for GTFS features (Fares v2, Flex, etc) that aren't explicitly supported yet.