### PR TITLE
Add new flag "keep-agency-names"

### DIFF
--- a/gtfsclean.go
+++ b/gtfsclean.go
@@ -541,18 +541,19 @@ func main() {
 		fmt.Fprintln(os.Stdout, "\nYou may want to try running gtfsclean with --fix for error fixing / skipping. See --help for details.")
 		os.Exit(1)
 	} else {
-		minzers := make([]processors.Processor, 0)
+            minzers := make([]processors.Processor, 0)
+            if len(*removeAgencyNames) > 0 && len(*keepAgencyNames) > 0 {
+                fmt.Fprintln(os.Stderr, "You cannot use both --drop-agency-names and --keep-agency-names at the same time.")
+                os.Exit(1)
+            }
 
-        if (removeAgencyNames != nil && len(*removeAgencyNames) > 0) || (keepAgencyNames != nil && len(*keepAgencyNames) > 0) {
-            minzers = append(minzers, processors.AgencyFilter{
-                NamesToRemove: *removeAgencyNames,
-                NamesToKeep:   *keepAgencyNames,
-            })
-        }
-        if len(*removeAgencyNames) > 0 && len(*keepAgencyNames) > 0 {
-            fmt.Fprintln(os.Stderr, "You cannot use both --drop-agency-names and --keep-agency-names at the same time.")
-            os.Exit(1)
-        }
+            if (removeAgencyNames != nil && len(*removeAgencyNames) > 0) || (keepAgencyNames != nil && len(*keepAgencyNames) > 0) {
+                minzers = append(minzers, processors.AgencyFilter{
+                    NamesToRemove: *removeAgencyNames,
+                    NamesToKeep:   *keepAgencyNames,
+                })
+            }
+
 
 		var err error = nil
 		var copyTripNameRe *regexp.Regexp = nil

--- a/gtfsclean.go
+++ b/gtfsclean.go
@@ -541,19 +541,18 @@ func main() {
 		fmt.Fprintln(os.Stdout, "\nYou may want to try running gtfsclean with --fix for error fixing / skipping. See --help for details.")
 		os.Exit(1)
 	} else {
-            minzers := make([]processors.Processor, 0)
-            if len(*removeAgencyNames) > 0 && len(*keepAgencyNames) > 0 {
-                fmt.Fprintln(os.Stderr, "You cannot use both --drop-agency-names and --keep-agency-names at the same time.")
-                os.Exit(1)
-            }
+		minzers := make([]processors.Processor, 0)
+		if len(*removeAgencyNames) > 0 && len(*keepAgencyNames) > 0 {
+			fmt.Fprintln(os.Stderr, "You cannot use both --drop-agency-names and --keep-agency-names at the same time.")
+			os.Exit(1)
+		}
 
-            if (removeAgencyNames != nil && len(*removeAgencyNames) > 0) || (keepAgencyNames != nil && len(*keepAgencyNames) > 0) {
-                minzers = append(minzers, processors.AgencyFilter{
-                    NamesToRemove: *removeAgencyNames,
-                    NamesToKeep:   *keepAgencyNames,
-                })
-            }
-
+		if (removeAgencyNames != nil && len(*removeAgencyNames) > 0) || (keepAgencyNames != nil && len(*keepAgencyNames) > 0) {
+			minzers = append(minzers, processors.AgencyFilter{
+				NamesToRemove: *removeAgencyNames,
+				NamesToKeep:   *keepAgencyNames,
+			})
+		}
 
 		var err error = nil
 		var copyTripNameRe *regexp.Regexp = nil

--- a/gtfsclean.go
+++ b/gtfsclean.go
@@ -132,6 +132,7 @@ func main() {
 	emptyStrRepl := flag.StringP("empty-str-repl", "p", "", "string to use if a non-critical required string field is empty (like stop_name, agency_name, ...)")
 	emptyAgencyUrlRepl := flag.String("empty-agency-url-repl", "", "url to use if agency_url is empty")
 	removeAgencyNames := flag.StringSlice("drop-agency-names", []string{}, "names of agencies to remove")
+	keepAgencyNames := flag.StringSlice("keep-agency-names", []string{}, "names of agencies to keep")
 	dropErroneousEntities := flag.BoolP("drop-errs", "D", false, "drop erroneous entries from feed")
 	checkNullCoords := flag.BoolP("check-null-coords", "n", false, "check for (0, 0) coordinates")
 
@@ -542,9 +543,16 @@ func main() {
 	} else {
 		minzers := make([]processors.Processor, 0)
 
-		if removeAgencyNames != nil && len(*removeAgencyNames) > 0 {
-			minzers = append(minzers, processors.AgencyFilter{NamesToRemove: *removeAgencyNames})
-		}
+        if (removeAgencyNames != nil && len(*removeAgencyNames) > 0) || (keepAgencyNames != nil && len(*keepAgencyNames) > 0) {
+            minzers = append(minzers, processors.AgencyFilter{
+                NamesToRemove: *removeAgencyNames,
+                NamesToKeep:   *keepAgencyNames,
+            })
+        }
+        if len(*removeAgencyNames) > 0 && len(*keepAgencyNames) > 0 {
+            fmt.Fprintln(os.Stderr, "You cannot use both --drop-agency-names and --keep-agency-names at the same time.")
+            os.Exit(1)
+        }
 
 		var err error = nil
 		var copyTripNameRe *regexp.Regexp = nil


### PR DESCRIPTION
With this flag, it's possible to keep a selected list of agencies instead of filling in all the other agencies of a dataset to let them remove. 

Related pull request transitous: https://github.com/public-transport/transitous/pull/1376